### PR TITLE
Chnaged psycopg2 version to 2.8.5 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ celery==4.2.1
 django-picklefield==0.3.0
 kombu==4.2.0
 html5lib==0.999
-psycopg2==2.7.3.2
+psycopg2==2.8.5
 pyparsing==1.5.7
 python-dateutil>=1.5
 python-openid==2.2.5


### PR DESCRIPTION
Had to change that since it does not run properly on Ubuntu 18.04 with the last updates.